### PR TITLE
Shuffle words experiment

### DIFF
--- a/training/train_distilbert.py
+++ b/training/train_distilbert.py
@@ -14,7 +14,7 @@ from dataset import load_splits
 
 
 MODEL_NAME = "distilbert/distilbert-base-uncased"
-OUTPUT_DIR = "models/distilbert_default"
+OUTPUT_DIR = "/content/drive/MyDrive/Deep-Learning/models/distilbert_default"
 MAX_LENGTH = 256
 
 

--- a/training/train_distilbert.py
+++ b/training/train_distilbert.py
@@ -115,7 +115,6 @@ def main():
         train_dataset=train_hf,
         eval_dataset=val_hf,
         compute_metrics=compute_metrics,
-        tokenizer=tokenizer,
         data_collator=data_collator,
     )
 

--- a/training/train_distilbert.py
+++ b/training/train_distilbert.py
@@ -8,6 +8,7 @@ from transformers import (
     AutoModelForSequenceClassification,
     TrainingArguments,
     Trainer,
+    DataCollatorWithPadding,
 )
 
 from dataset import load_splits
@@ -15,7 +16,7 @@ from dataset import load_splits
 
 MODEL_NAME = "distilbert/distilbert-base-uncased"
 OUTPUT_DIR = "/content/drive/MyDrive/Deep-Learning/models/distilbert_default"
-MAX_LENGTH = 256
+MAX_LENGTH = 128
 
 
 def compute_metrics(eval_pred):
@@ -41,7 +42,6 @@ def tokenize_function(examples, tokenizer):
     return tokenizer(
         examples["input_text"],
         truncation=True,
-        padding="max_length",
         max_length=MAX_LENGTH,
     )
 
@@ -61,6 +61,7 @@ def main():
     )
 
     tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+    data_collator = DataCollatorWithPadding(tokenizer=tokenizer)
 
     train_hf = train_hf.map(
         lambda batch: tokenize_function(batch, tokenizer),
@@ -92,18 +93,19 @@ def main():
     # Training configuration
     training_args = TrainingArguments(
         output_dir=OUTPUT_DIR,
-        eval_strategy="epoch",
+        evaluation_strategy="epoch",
         save_strategy="epoch",
         logging_strategy="epoch",
         learning_rate=2e-5,
-        per_device_train_batch_size=8,
-        per_device_eval_batch_size=8,
+        per_device_train_batch_size=16,
+        per_device_eval_batch_size=16,
         num_train_epochs=3,
         weight_decay=0.01,
         load_best_model_at_end=True,
         metric_for_best_model="f1",
         save_total_limit=2,
         report_to="none",
+        fp16=True,
     )
 
     # Trainer handles training loop, evaluation, and saving
@@ -113,6 +115,8 @@ def main():
         train_dataset=train_hf,
         eval_dataset=val_hf,
         compute_metrics=compute_metrics,
+        tokenizer=tokenizer,
+        data_collator=data_collator,
     )
 
     # Fine-tune the model

--- a/training/train_distilbert.py
+++ b/training/train_distilbert.py
@@ -93,7 +93,7 @@ def main():
     # Training configuration
     training_args = TrainingArguments(
         output_dir=OUTPUT_DIR,
-        evaluation_strategy="epoch",
+        eval_strategy="epoch", 
         save_strategy="epoch",
         logging_strategy="epoch",
         learning_rate=2e-5,

--- a/training/train_distilbert.py
+++ b/training/train_distilbert.py
@@ -16,7 +16,7 @@ from dataset import load_splits
 
 MODEL_NAME = "distilbert/distilbert-base-uncased"
 OUTPUT_DIR = "/content/drive/MyDrive/Deep-Learning/models/distilbert_default"
-MAX_LENGTH = 128
+MAX_LENGTH = 256
 
 
 def compute_metrics(eval_pred):


### PR DESCRIPTION
Logistic Regression performs similarly, while DistilBERT shows a performance drop with increasing shuffling.

<p><b>No shuffling:</b></p>
<p>
<img width="366" height="301" alt="image" src="https://github.com/user-attachments/assets/b8deb265-37f5-4bfb-889d-c0dcf2c3cec0" />
<img width="366" height="301" alt="image" src="https://github.com/user-attachments/assets/6a4e9319-6f42-42c7-a6ef-be66e4761cba" />
</p>

<p><b>10%:</b></p>
<p>
<img width="365" height="302" alt="image" src="https://github.com/user-attachments/assets/0ffe240c-37f1-4586-821d-f07c7a2fdf83" />
<img width="366" height="299" alt="image" src="https://github.com/user-attachments/assets/f7fc5255-1a9a-4080-a6b7-4559a68acd2f" />
</p>

<p><b>30%:</b></p>
<p>
<img width="366" height="297" alt="image" src="https://github.com/user-attachments/assets/6c4c826d-ef66-4cf9-8b3f-3bae2098a1cc" />
<img width="364" height="297" alt="image" src="https://github.com/user-attachments/assets/840b77e4-2d01-4e7d-b48d-5995eb4de28c" />
</p>

<p><b>50%:</b></p>
<p>
<img width="366" height="301" alt="image" src="https://github.com/user-attachments/assets/1b50f314-c869-4e77-86cf-a3a5cb456bcb" />
<img width="364" height="272" alt="image" src="https://github.com/user-attachments/assets/1e5986f1-ec04-4645-bfc3-61f5f2d2b2f6" />
</p>